### PR TITLE
Bug/parsing

### DIFF
--- a/tools/model.go
+++ b/tools/model.go
@@ -261,7 +261,9 @@ func getProjection(rm *RasModel, fn string, wg *sync.WaitGroup, errChan chan err
 
 	sourceSpRef := gdal.CreateSpatialReference(line)
 	if err := sourceSpRef.Validate(); err != nil {
-		rm.Metadata.Projection = ""
+		if filepath.Ext(fn) == ".prj" {
+			fmt.Println(fmt.Sprintf("%s is not a valid projection file, check that there are not multiple project files.\n", fn))
+		}
 		return
 	}
 	if rm.Metadata.Projection != "" {


### PR DESCRIPTION
This PR addresses edge cases, which were identified while testing the MCAT. 
- A print statement was added to notify the user of two or more .prj files in the same directory when the second .prj is not a valid projection file.
- Non-numeric characters are stripped from a cross-section's station to avoid parsing errors.
- The length of a cross-section's 2D cutline is compared to its profile length in order to avoid building a 3D cross-section linestring from station elevation data that does not match the cutline geometry. This edge case occurs when an engineer adjusts the cross-sectional profile without updating the cutline. 