### PR TITLE
Check AWS error during Ping request, resolves #2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/USACE/filestore v0.1.1
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+	github.com/aws/aws-sdk-go v1.31.0
 	github.com/dewberry/gdal v0.3.1
 	github.com/labstack/echo/v4 v4.1.17
 	github.com/swaggo/echo-swagger v1.1.0


### PR DESCRIPTION
This PR resolves #2, by checking the error code returned by the GetObjectAcl request which is called by the RAS MCAT ping request. If the error code is "AccessDenied" then we know the ping was successful, however, if the code is something else, the ping fails and returns that code. For example, if the user enters and invalid access key, the ping fails with the following message: 
![image](https://user-images.githubusercontent.com/13066481/105856656-787c5480-5fb7-11eb-8b68-d110699f9dd8.png)
