### PR TITLE
Update the filestore release to resolve #2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/USACE/mcat-ras
 go 1.15
 
 require (
-	github.com/USACE/filestore v0.1.1
+	github.com/USACE/filestore v0.1.4
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/dewberry/gdal v0.3.1
 	github.com/labstack/echo/v4 v4.1.17


### PR DESCRIPTION
This PR resolves #2 using the most recent release of filestore. The S3FS ping method within filestore now uses ListObjectsV2 instead of GetObjectAcl to check the connection to an S3 bucket, avoiding the "AccessDenied" error that was returned when a user had restricted permissions.