### PR TITLE
Feature/update isamodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Contains the HEC-RAS model content and analysis tool (MCAT). Given a .prj file, 
 
 The MCAT includes:
 - a standard set of methods to evaluate a model's content:
+    - isamodel
 	- modeltype
     - modelversion
-    - isamodel
+    - index
     - isgeospatial
-	- index
 	- geospatialdata
 - an API for executing the above methods.
 - a docker container for running the methods and API.
@@ -42,18 +42,18 @@ The following requests can be used to interrogate a model whose storage location
 
 `GET /isamodel?definition_file=<s3_key>`
 
-`GET /isgeospatial?definition_file=<s3_key>`
-
 `GET /modeltype?definition_file=<s3_key>`
 
 `GET /modelversion?definition_file=<s3_key>`
 
 `GET /index?definition_file=<s3_key>`
 
+`GET /isgeospatial?definition_file=<s3_key>`
+
 `GET /geospatialdata?definition_file=<s3_key>`
 
 
-*For example: `http://mcat-ras:5600/isamodel?definition_file=models/ras/ex_model.prj`*
+*For example: `http://mcat-ras:5600/isamodel?definition_file=models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj`*
 
 
 ### Swagger Documentation:

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -44,7 +44,7 @@ var doc = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -82,7 +82,7 @@ var doc = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -92,7 +92,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ras.Model"
+                            "$ref": "#/definitions/tools.Model"
                         }
                     },
                     "500": {
@@ -120,7 +120,7 @@ var doc = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -152,7 +152,7 @@ var doc = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -184,7 +184,7 @@ var doc = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -222,7 +222,7 @@ var doc = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -280,7 +280,7 @@ var doc = `{
                 }
             }
         },
-        "ras.ControlFiles": {
+        "tools.ControlFiles": {
             "type": "object",
             "properties": {
                 "data": {
@@ -296,7 +296,7 @@ var doc = `{
                 }
             }
         },
-        "ras.ForcingFiles": {
+        "tools.ForcingFiles": {
             "type": "object",
             "properties": {
                 "data": {
@@ -312,7 +312,7 @@ var doc = `{
                 }
             }
         },
-        "ras.GeometryFiles": {
+        "tools.GeometryFiles": {
             "type": "object",
             "properties": {
                 "featuresProperties": {
@@ -332,17 +332,17 @@ var doc = `{
                 }
             }
         },
-        "ras.InputFiles": {
+        "tools.InputFiles": {
             "type": "object",
             "properties": {
                 "controlFiles": {
-                    "$ref": "#/definitions/ras.ControlFiles"
+                    "$ref": "#/definitions/tools.ControlFiles"
                 },
                 "forcingFiles": {
-                    "$ref": "#/definitions/ras.ForcingFiles"
+                    "$ref": "#/definitions/tools.ForcingFiles"
                 },
                 "geometryFiles": {
-                    "$ref": "#/definitions/ras.GeometryFiles"
+                    "$ref": "#/definitions/tools.GeometryFiles"
                 },
                 "localVariables": {
                     "description": "placeholder",
@@ -354,14 +354,14 @@ var doc = `{
                 }
             }
         },
-        "ras.Model": {
+        "tools.Model": {
             "type": "object",
             "properties": {
                 "definitionFile": {
                     "type": "string"
                 },
                 "files": {
-                    "$ref": "#/definitions/ras.ModelFiles"
+                    "$ref": "#/definitions/tools.ModelFiles"
                 },
                 "type": {
                     "type": "string"
@@ -371,21 +371,21 @@ var doc = `{
                 }
             }
         },
-        "ras.ModelFiles": {
+        "tools.ModelFiles": {
             "type": "object",
             "properties": {
                 "inputFiles": {
-                    "$ref": "#/definitions/ras.InputFiles"
+                    "$ref": "#/definitions/tools.InputFiles"
                 },
                 "outputFiles": {
-                    "$ref": "#/definitions/ras.OutputFiles"
+                    "$ref": "#/definitions/tools.OutputFiles"
                 },
                 "supplementalFiles": {
-                    "$ref": "#/definitions/ras.SupplementalFiles"
+                    "$ref": "#/definitions/tools.SupplementalFiles"
                 }
             }
         },
-        "ras.OutputFiles": {
+        "tools.OutputFiles": {
             "type": "object",
             "properties": {
                 "modelPrediction": {
@@ -412,7 +412,7 @@ var doc = `{
                 }
             }
         },
-        "ras.SupplementalFiles": {
+        "tools.SupplementalFiles": {
             "type": "object",
             "properties": {
                 "observationalData": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -28,7 +28,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -66,7 +66,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -76,7 +76,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ras.Model"
+                            "$ref": "#/definitions/tools.Model"
                         }
                     },
                     "500": {
@@ -104,7 +104,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -136,7 +136,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -168,7 +168,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -206,7 +206,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj",
+                        "description": "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj",
                         "name": "definition_file",
                         "in": "query",
                         "required": true
@@ -264,7 +264,7 @@
                 }
             }
         },
-        "ras.ControlFiles": {
+        "tools.ControlFiles": {
             "type": "object",
             "properties": {
                 "data": {
@@ -280,7 +280,7 @@
                 }
             }
         },
-        "ras.ForcingFiles": {
+        "tools.ForcingFiles": {
             "type": "object",
             "properties": {
                 "data": {
@@ -296,7 +296,7 @@
                 }
             }
         },
-        "ras.GeometryFiles": {
+        "tools.GeometryFiles": {
             "type": "object",
             "properties": {
                 "featuresProperties": {
@@ -316,17 +316,17 @@
                 }
             }
         },
-        "ras.InputFiles": {
+        "tools.InputFiles": {
             "type": "object",
             "properties": {
                 "controlFiles": {
-                    "$ref": "#/definitions/ras.ControlFiles"
+                    "$ref": "#/definitions/tools.ControlFiles"
                 },
                 "forcingFiles": {
-                    "$ref": "#/definitions/ras.ForcingFiles"
+                    "$ref": "#/definitions/tools.ForcingFiles"
                 },
                 "geometryFiles": {
-                    "$ref": "#/definitions/ras.GeometryFiles"
+                    "$ref": "#/definitions/tools.GeometryFiles"
                 },
                 "localVariables": {
                     "description": "placeholder",
@@ -338,14 +338,14 @@
                 }
             }
         },
-        "ras.Model": {
+        "tools.Model": {
             "type": "object",
             "properties": {
                 "definitionFile": {
                     "type": "string"
                 },
                 "files": {
-                    "$ref": "#/definitions/ras.ModelFiles"
+                    "$ref": "#/definitions/tools.ModelFiles"
                 },
                 "type": {
                     "type": "string"
@@ -355,21 +355,21 @@
                 }
             }
         },
-        "ras.ModelFiles": {
+        "tools.ModelFiles": {
             "type": "object",
             "properties": {
                 "inputFiles": {
-                    "$ref": "#/definitions/ras.InputFiles"
+                    "$ref": "#/definitions/tools.InputFiles"
                 },
                 "outputFiles": {
-                    "$ref": "#/definitions/ras.OutputFiles"
+                    "$ref": "#/definitions/tools.OutputFiles"
                 },
                 "supplementalFiles": {
-                    "$ref": "#/definitions/ras.SupplementalFiles"
+                    "$ref": "#/definitions/tools.SupplementalFiles"
                 }
             }
         },
-        "ras.OutputFiles": {
+        "tools.OutputFiles": {
             "type": "object",
             "properties": {
                 "modelPrediction": {
@@ -396,7 +396,7 @@
                 }
             }
         },
-        "ras.SupplementalFiles": {
+        "tools.SupplementalFiles": {
             "type": "object",
             "properties": {
                 "observationalData": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6,7 +6,7 @@ definitions:
       status:
         type: integer
     type: object
-  ras.ControlFiles:
+  tools.ControlFiles:
     properties:
       data:
         additionalProperties: true
@@ -17,7 +17,7 @@ definitions:
           type: string
         type: array
     type: object
-  ras.ForcingFiles:
+  tools.ForcingFiles:
     properties:
       data:
         additionalProperties: true
@@ -28,7 +28,7 @@ definitions:
           type: string
         type: array
     type: object
-  ras.GeometryFiles:
+  tools.GeometryFiles:
     properties:
       featuresProperties:
         additionalProperties: true
@@ -42,14 +42,14 @@ definitions:
           type: string
         type: array
     type: object
-  ras.InputFiles:
+  tools.InputFiles:
     properties:
       controlFiles:
-        $ref: '#/definitions/ras.ControlFiles'
+        $ref: '#/definitions/tools.ControlFiles'
       forcingFiles:
-        $ref: '#/definitions/ras.ForcingFiles'
+        $ref: '#/definitions/tools.ForcingFiles'
       geometryFiles:
-        $ref: '#/definitions/ras.GeometryFiles'
+        $ref: '#/definitions/tools.GeometryFiles'
       localVariables:
         description: placeholder
         type: object
@@ -57,27 +57,27 @@ definitions:
         description: placeholder
         type: object
     type: object
-  ras.Model:
+  tools.Model:
     properties:
       definitionFile:
         type: string
       files:
-        $ref: '#/definitions/ras.ModelFiles'
+        $ref: '#/definitions/tools.ModelFiles'
       type:
         type: string
       version:
         type: string
     type: object
-  ras.ModelFiles:
+  tools.ModelFiles:
     properties:
       inputFiles:
-        $ref: '#/definitions/ras.InputFiles'
+        $ref: '#/definitions/tools.InputFiles'
       outputFiles:
-        $ref: '#/definitions/ras.OutputFiles'
+        $ref: '#/definitions/tools.OutputFiles'
       supplementalFiles:
-        $ref: '#/definitions/ras.SupplementalFiles'
+        $ref: '#/definitions/tools.SupplementalFiles'
     type: object
-  ras.OutputFiles:
+  tools.OutputFiles:
     properties:
       modelPrediction:
         description: placeholder
@@ -95,7 +95,7 @@ definitions:
           type: string
         type: array
     type: object
-  ras.SupplementalFiles:
+  tools.SupplementalFiles:
     properties:
       observationalData:
         description: placeholder
@@ -124,7 +124,7 @@ paths:
       - application/json
       description: Extract geospatial data from a RAS model given an s3 key
       parameters:
-      - description: /pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj
+      - description: /models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj
         in: query
         name: definition_file
         required: true
@@ -149,7 +149,7 @@ paths:
       - application/json
       description: Extract metadata from a RAS model given an s3 key
       parameters:
-      - description: /pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj
+      - description: /models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj
         in: query
         name: definition_file
         required: true
@@ -160,7 +160,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ras.Model'
+            $ref: '#/definitions/tools.Model'
         "500":
           description: Internal Server Error
           schema:
@@ -174,7 +174,7 @@ paths:
       - application/json
       description: Check if the given key is a RAS model
       parameters:
-      - description: /pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj
+      - description: /models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj
         in: query
         name: definition_file
         required: true
@@ -195,7 +195,7 @@ paths:
       - application/json
       description: Check if the RAS model has geospatial information
       parameters:
-      - description: /pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj
+      - description: /models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj
         in: query
         name: definition_file
         required: true
@@ -216,7 +216,7 @@ paths:
       - application/json
       description: Extract the model type given an s3 key
       parameters:
-      - description: /pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj
+      - description: /models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj
         in: query
         name: definition_file
         required: true
@@ -241,7 +241,7 @@ paths:
       - application/json
       description: Extract the RAS model version given an s3 key
       parameters:
-      - description: /pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj
+      - description: /models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj
         in: query
         name: definition_file
         required: true

--- a/handlers/geospatialdata.go
+++ b/handlers/geospatialdata.go
@@ -15,7 +15,7 @@ import (
 // @Tags MCAT
 // @Accept json
 // @Produce json
-// @Param definition_file query string true "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj"
+// @Param definition_file query string true "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj"
 // @Success 200 {object} interface{}
 // @Failure 500 {object} SimpleResponse
 // @Router /geospatialdata [get]

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -15,7 +15,7 @@ import (
 // @Tags MCAT
 // @Accept json
 // @Produce json
-// @Param definition_file query string true "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj"
+// @Param definition_file query string true "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj"
 // @Success 200 {object} ras.Model
 // @Failure 500 {object} SimpleResponse
 // @Router /index [get]

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -28,11 +28,8 @@ func Index(fs *filestore.FileStore) echo.HandlerFunc {
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error()})
 		}
-		// mod, err := rm.Index()
-		// if err != nil {
-		// 	return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error()})
-		// }
+		mod := rm.Index()
 
-		return c.JSON(http.StatusOK, rm)
+		return c.JSON(http.StatusOK, mod)
 	}
 }

--- a/handlers/isamodel.go
+++ b/handlers/isamodel.go
@@ -15,7 +15,7 @@ import (
 // @Tags MCAT
 // @Accept json
 // @Produce json
-// @Param definition_file query string true "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj"
+// @Param definition_file query string true "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj"
 // @Success 200 {object} bool
 // @Router /isamodel [get]
 func IsAModel(fs *filestore.FileStore) echo.HandlerFunc {

--- a/handlers/isgeospatial.go
+++ b/handlers/isgeospatial.go
@@ -25,7 +25,7 @@ func IsGeospatial(fs *filestore.FileStore) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *fs)
 		if err != nil {
-			return c.JSON(http.StatusOK, false)
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error()})
 		}
 		isIt := rm.IsGeospatial()
 

--- a/handlers/isgeospatial.go
+++ b/handlers/isgeospatial.go
@@ -11,11 +11,11 @@ import (
 
 // IsGeospatial godoc
 // @Summary Check if the RAS model has geospatial information
-// @Description  Check if the RAS model has geospatial information
+// @Description Check if the RAS model has geospatial information
 // @Tags MCAT
 // @Accept json
 // @Produce json
-// @Param definition_file query string true "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj"
+// @Param definition_file query string true "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj"
 // @Success 200 {object} bool
 // @Router /isgeospatial [get]
 func IsGeospatial(fs *filestore.FileStore) echo.HandlerFunc {

--- a/handlers/modeltype.go
+++ b/handlers/modeltype.go
@@ -15,7 +15,7 @@ import (
 // @Tags MCAT
 // @Accept json
 // @Produce json
-// @Param definition_file query string true "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj"
+// @Param definition_file query string true "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj"
 // @Success 200 {string} string "RAS"
 // @Failure 500 {object} SimpleResponse
 // @Router /modeltype [get]

--- a/handlers/modelversion.go
+++ b/handlers/modelversion.go
@@ -15,7 +15,7 @@ import (
 // @Tags MCAT
 // @Accept json
 // @Produce json
-// @Param definition_file query string true "/pfra-models/mipmodels/MD/M000309/T1ChptnkR.prj"
+// @Param definition_file query string true "/models/ras/CHURCH HOUSE GULLY/CHURCH HOUSE GULLY.prj"
 // @Success 200 {string} string "4.0"
 // @Failure 500 {object} SimpleResponse
 // @Router /modelversion [get]

--- a/main.go
+++ b/main.go
@@ -34,11 +34,11 @@ func main() {
 	e.GET("/swagger/*", echoSwagger.WrapHandler)
 
 	// ras endpoints
-	e.GET("/index", handlers.Index(appConfig.FileStore))
 	e.GET("/isamodel", handlers.IsAModel(appConfig.FileStore))
-	e.GET("/isgeospatial", handlers.IsGeospatial(appConfig.FileStore))
 	e.GET("/modeltype", handlers.ModelType(appConfig.FileStore))
 	e.GET("/modelversion", handlers.ModelVersion(appConfig.FileStore))
+	e.GET("/index", handlers.Index(appConfig.FileStore))
+	e.GET("/isgeospatial", handlers.IsGeospatial(appConfig.FileStore))
 	e.GET("/geospatialdata", handlers.GeospatialData(appConfig))
 
 	e.Logger.Fatal(e.Start(appConfig.Address()))


### PR DESCRIPTION
This PR updates the isamodel, index, and isgeospatial methods and swagger docs.
- The passed S3 key is said to be a model if the key is a .prj file, which exists and is valid, and if there is at least one geometry file in the same directory as the .prj file. 
- The index method now returns the general MCAT Model struct instead of the RasModel struct.
- A model is said to be geospatial if it is a model and if a valid projection is identified. 