### PR TITLE
get projection from .projection file first #patch

### DIFF
--- a/tools/model.go
+++ b/tools/model.go
@@ -343,7 +343,7 @@ func NewRasModel(key string, fs filestore.FileStore) (*RasModel, error) {
 			go getFlowData(&rm, fp, &rasWG.Flow)
 
 		case rm.Metadata.Projection == "" && rasRE.Projection.MatchString(ext):
-			if filepath.Base(key) != filepath.Base(fp) {
+			if filepath.Base(key) != filepath.Base(fp) && fp != projecFile {
 				rasWG.Projection.Add(1)
 				go getProjection(&rm, fp, &rasWG.Projection)
 			}

--- a/tools/model.go
+++ b/tools/model.go
@@ -281,15 +281,12 @@ func getProjection(rm *RasModel, fn string, wg *sync.WaitGroup) {
 
 	sourceSpRef := gdal.CreateSpatialReference(line)
 	if err := sourceSpRef.Validate(); err != nil {
-		if filepath.Ext(fn) == ".prj" {
-			fmt.Println(fmt.Sprintf("%s is not a valid projection file.\n", fn))
-		} else {
-			fmt.Println(err)
-		}
+		fmt.Println(fmt.Sprintf("%s is not a valid projection file.\n", fn))
+		fmt.Println(err)
 		return
 	}
 	if rm.Metadata.Projection != "" {
-		fmt.Println("Projection already assigned to the model from another file in the directory.")
+		fmt.Println("Projection already exist for the model.")
 		return
 	}
 


### PR DESCRIPTION
This PR:
- Change getting projection logic by first trying to get exactly from model.projection file and then if that doesn't exist then try to get from other .prj or .projection files.
- Improve error messages.